### PR TITLE
Fix build on macOS by moving grpcurl to expected path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 .next
 node_modules
 out
+
+# MacOS .DS_Store files
+.DS_Store


### PR DESCRIPTION
Hi! I wanted to run the project from the master branch but got errors when issuing calls. Apparently the path of `grpcurl` in the repo was different from what was expected according to `export const execPath = path.resolve(path.join(binariesPath, './grpcurl'));` in `binaries.js`. If this was a setup error on my part please let me know what I did wrong :) 